### PR TITLE
bump ava-labs/avalanchego to v1.1.4-rc.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "avalanche.public.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v1.1.2",
+  "upstreamVersion": "v1.1.4-rc.1",
   "upstreamRepo": "ava-labs/avalanchego",
   "shortDescription": "Avalanche",
   "description": "Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
@@ -31,7 +31,6 @@
     "Edu (https://github.com/eduadiez)"
   ],
   "architectures": ["linux/amd64", "linux/arm64"],
-
   "repository": {
     "type": "git",
     "url": "https://github.com/Colm3na/DAppNodePackage-avalanche.git"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: build
       args:
-        UPSTREAM_VERSION: v1.1.2
+        UPSTREAM_VERSION: v1.1.4-rc.1
     image: "avalanche.avalanche.public.dappnode.eth:0.1.0"
     volumes:
       - "chain:/root/.avalanchego/db"


### PR DESCRIPTION
Bumps upstream version

- [ava-labs/avalanchego](https://github.com/ava-labs/avalanchego) from v1.1.2 to [v1.1.4-rc.1](https://github.com/ava-labs/avalanchego/releases/tag/v1.1.4-rc.1)