### PR TITLE
bump ava-labs/avalanchego to v1.1.3

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "avalanche.public.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v1.1.2",
+  "upstreamVersion": "v1.1.3",
   "upstreamRepo": "ava-labs/avalanchego",
   "shortDescription": "Avalanche",
   "description": "Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
@@ -31,7 +31,6 @@
     "Edu (https://github.com/eduadiez)"
   ],
   "architectures": ["linux/amd64", "linux/arm64"],
-
   "repository": {
     "type": "git",
     "url": "https://github.com/Colm3na/DAppNodePackage-avalanche.git"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -19,9 +19,6 @@
   "disclaimer": {
     "message": "This software is experimental, presented 'as is' and inherently carries risks. By installing it, you acknowledge that DAppNode Association has done its best to mitigate these risks and accept to waive any liability or responsibility for DAppNode in case of any shortage, discrepancy, damage, loss or destruction of any digital asset managed within this DAppNode package.\n\nThis package stores private keys, which will be stored in your DAppNode. Neither DAppNode Association nor the developers of this software can have access to your private key, nor help you recover it if you lose it. \n\nYou are solely responsible for keeping your private keys and password safe and to perform secure backups, as well as to restrict access to your computer and other equipment. To the extent permitted by applicable law, you agree to be responsible for all activities that have been conducted from your account. You must take all necessary steps to ensure that your private key, password, and recovery phrase remain confidential and secured."
   },
-  "globalEnvs": {
-    "all": "true"
-  },
   "author": "La ColmenaSVQ (https://github.com/Colm3na)",
   "contributors": [
     "Wimel (https://github.com/wimel)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: build
       args:
-        UPSTREAM_VERSION: v1.1.2
+        UPSTREAM_VERSION: v1.1.3
     image: "avalanche.avalanche.public.dappnode.eth:0.1.0"
     volumes:
       - "chain:/root/.avalanchego/db"


### PR DESCRIPTION
Bumps upstream version

- [ava-labs/avalanchego](https://github.com/ava-labs/avalanchego) from v1.1.2 to [v1.1.3](https://github.com/ava-labs/avalanchego/releases/tag/v1.1.3)