### PR TITLE
bump ava-labs/avalanchego to v1.1.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,6 +18,6 @@ RUN ln -s /root/avalanchego/avalanchego /usr/local/bin
 
 ENTRYPOINT [ "sh", "-c", "exec avalanchego \
     --dynamic-public-ip ifconfigco \
-    --plugin-dir /root/avalanchego/build/plugins \
+    --plugin-dir /root/avalanchego/plugins \
     --http-host 0.0.0.0 \
     $EXTRA_OPTS" ]

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -39,6 +39,7 @@
     "url": "https://github.com/Colm3na/DAppNodePackage-avalanche/issues"
   },
   "links": {
-    "avalabs": "https://www.avalabs.org/"
+    "avalabs": "https://www.avalabs.org/",
+    "upstream releases": "https://github.com/ava-labs/avalanchego/releases"
   }
 }

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "avalanche.public.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v1.1.2",
+  "upstreamVersion": "v1.1.3",
   "upstreamRepo": "ava-labs/avalanchego",
   "shortDescription": "Avalanche",
   "description": "Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",
@@ -31,7 +31,6 @@
     "Edu (https://github.com/eduadiez)"
   ],
   "architectures": ["linux/amd64", "linux/arm64"],
-
   "repository": {
     "type": "git",
     "url": "https://github.com/Colm3na/DAppNodePackage-avalanche.git"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: build
       args:
-        UPSTREAM_VERSION: v1.1.2
+        UPSTREAM_VERSION: v1.1.3
     image: "avalanche.avalanche.public.dappnode.eth:0.1.0"
     volumes:
       - "chain:/root/.avalanchego/db"


### PR DESCRIPTION
Bumps upstream version

- [ava-labs/avalanchego](https://github.com/ava-labs/avalanchego) from v1.1.2 to [v1.1.3](https://github.com/ava-labs/avalanchego/releases/tag/v1.1.3)