### PR TITLE
bump ava-labs/avalanchego to v1.2.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "avalanche.public.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v1.1.3",
+  "upstreamVersion": "v1.2.0",
   "upstreamRepo": "ava-labs/avalanchego",
   "shortDescription": "Avalanche",
   "description": "Avalanche is an open-source platform for launching highly decentralized applications, new financial primitives, and new interoperable blockchains.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: build
       args:
-        UPSTREAM_VERSION: v1.1.3
+        UPSTREAM_VERSION: v1.2.0
     image: "avalanche.avalanche.public.dappnode.eth:0.1.0"
     volumes:
       - "chain:/root/.avalanchego/db"


### PR DESCRIPTION
Bumps upstream version

- [ava-labs/avalanchego](https://github.com/ava-labs/avalanchego) from v1.1.3 to [v1.2.0](https://github.com/ava-labs/avalanchego/releases/tag/v1.2.0)