### PR TITLE
Port standarization

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,4 +18,5 @@ RUN ln -s /root/avalanchego/avalanchego /usr/local/bin
 
 ENTRYPOINT [ "sh", "-c", "exec avalanchego \
     --http-host 0.0.0.0 \
+    --staking-port=$P2P_PORT \
     $EXTRA_OPTS" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,10 @@ services:
       - "chain:/root/.avalanchego/db"
       - "validator:/root/.avalanchego/staking"
     environment:
-      - EXTRA_OPTS
+      - P2P_PORT=21061
+      - EXTRA_OPT=""
     ports:
-      - "9651"
+      - "21061:21061/tcp"
     restart: unless-stopped
   wallet:
     build:


### PR DESCRIPTION
Add env value, port assigned, flag to personalized the p2p port according to the avalanche docs and fix the opts value.
According to this issue https://github.com/dappnode/DAppNode/issues/457
We are selecting the host port for the client.