### PR TITLE
update endpoint link title

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -38,6 +38,6 @@
   "links": {
     "Avalabs": "https://www.avalabs.org/",
     "upstream releases": "https://github.com/ava-labs/avalanchego/releases",
-    "RPC Endpoint": "http://avalanche.avalanche.public.dappnode:9650/ext/bc/C/rpc"
+    "endpoint": "http://avalanche.avalanche.public.dappnode:9650/ext/bc/C/rpc"
   }
 }


### PR DESCRIPTION
update endpoint link title so that the endpoint is properly displayed in the dappmanager. (required to be `endpoint`, `api`, or `queryingApi` to show the endpoint in an easily selectable box for copy pasting.)
