### PR TITLE
Fix #124 Update node image to build wallet (needs >15 and <17)

### DIFF
--- a/build-ui/Dockerfile
+++ b/build-ui/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:15.6-buster-slim as build-deps
+FROM node:16.20.2-buster-slim as build-deps
 
 WORKDIR /usr/src/app
 
 RUN apt-get update && \ 
-    apt-get install -y git g++ build-essential python && \
+    apt-get install -y git g++ build-essential python3 && \
     git clone https://github.com/ava-labs/avalanche-wallet.git . 
 
 COPY constants.ts /usr/src/app/src/store/modules/network/constants.ts


### PR DESCRIPTION
Fixed #124 